### PR TITLE
Fix networking with systemd

### DIFF
--- a/rpi23-gen-image.sh
+++ b/rpi23-gen-image.sh
@@ -466,6 +466,10 @@ if [ "$ENABLE_REDUCE" = true ] ; then
   fi
 fi
 
+if [ "$RELEASE" != "jessie" ] ; then
+  APT_INCLUDES="${APT_INCLUDES},libnss-systemd"
+fi
+
 # Configure kernel sources if no KERNELSRC_DIR
 if [ "$BUILD_KERNEL" = true ] && [ -z "$KERNELSRC_DIR" ] ; then
   KERNELSRC_CONFIG=true


### PR DESCRIPTION
With newer systemd builds, systemd-networkd does not boot anymore, leading to the network being disabled. Installing libnss-systemd resolves this problem, but it is not available on Jessie systems.

The error this PR aims to fix:

```
Jul 01 08:58:09 foo systemd-networkd[563]: Cannot resolve user name systemd-network: No such process
Jul 01 08:58:10 foo systemd[1]: systemd-networkd.service: Main process exited, code=exited, status=1/FAILURE
Jul 01 08:58:10 foo systemd[1]: systemd-networkd.service: Failed with result 'exit-code'.
```